### PR TITLE
Add additional build options for macs2

### DIFF
--- a/Dockerfiles/Churros/macs.sh
+++ b/Dockerfiles/Churros/macs.sh
@@ -55,7 +55,7 @@ mode=$5
 
 ex(){ echo $1; eval $1; }
 
-if test $build = "hg19" -o $build = "hg38" -o $build = "T2T"; then
+if test $build = "hg19" -o $build = "hg38" -o $build = "T2T" -o "$build" = "hap1" -o "$build" = "hap2" -o "$build" = "RPE1_hap1" -o "$build" = "RPE1_hap2"; then
     sp="hs"
 elif test $build = "mm9" -o $build = "mm10" -o $build = "mm39"; then
     sp="mm"

--- a/Dockerfiles/Churros/macs.sh
+++ b/Dockerfiles/Churros/macs.sh
@@ -55,7 +55,7 @@ mode=$5
 
 ex(){ echo $1; eval $1; }
 
-if test $build = "hg19" -o $build = "hg38" -o $build = "T2T" -o "$build" = "hap1" -o "$build" = "hap2" -o "$build" = "RPE1_hap1" -o "$build" = "RPE1_hap2"; then
+if test $build = "hg19" -o $build = "hg38" -o $build = "T2T" -o $build = "hap1" -o $build = "hap2" -o $build = "RPE1_hap1" -o $build = "RPE1_hap2"; then
     sp="hs"
 elif test $build = "mm9" -o $build = "mm10" -o $build = "mm39"; then
     sp="mm"


### PR DESCRIPTION
I identified an issue in churros_callpeak: because the build for RPE was not configured, the effective genome size was set to 1.00e+08.
So, I updated macs.sh to include the following build conditions:
"hap1", "hap2", "RPE1_hap1", and "RPE1_hap2".